### PR TITLE
change color cmd

### DIFF
--- a/addons/sourcemod/scripting/Shop_Chat.sp
+++ b/addons/sourcemod/scripting/Shop_Chat.sp
@@ -149,8 +149,8 @@ public void OnPluginStart()
 	g_hCookie[PREFIX_COLOR] = RegClientCookie("Shop Prefix Color", "Prefix Color", CookieAccess_Public);
 	g_hCookie[PREFIX] = RegClientCookie("Shop Prefix", "Prefix", CookieAccess_Public);
 
-	RegConsoleCmd("sm_color", MyColor_CMD);
-	RegConsoleCmd("sm_myprefix", MyPref_CMD);
+	RegConsoleCmd("sm_shopcolor", MyColor_CMD);
+	RegConsoleCmd("sm_shoptag", MyPref_CMD);
 
 	if (g_bLate && Shop_IsStarted())
 	{


### PR DESCRIPTION
change shop color & tag commands because GlowColors plugin has the same color command https://github.com/srcdslab/sm-plugin-GlowColors/blob/dfe6df37f49737eb3cbf57cf8f7963960c484a4b/addons/sourcemod/scripting/GlowColors.sp#L47